### PR TITLE
HTTP::Commands::{Get,Post} can be dependencies

### DIFF
--- a/lib/http/commands/controls/dialogs.rb
+++ b/lib/http/commands/controls/dialogs.rb
@@ -2,6 +2,19 @@ module HTTP
   module Commands
     module Controls
       module Dialogs
+        module Connection
+          def self.example(expected_request=nil, expected_response=nil)
+            if expected_request.nil? && expected_response.nil?
+              expected_request, expected_response = Get.example
+            end
+
+            connection = ::Connection::Client::Substitute.build
+            connection.expect_write expected_request
+            connection.expect_read expected_response
+            connection
+          end
+        end
+
         module Get
           def self.connection_closed
             request = Messages::Requests::Get.example

--- a/lib/http/commands/controls/messages/requests.rb
+++ b/lib/http/commands/controls/messages/requests.rb
@@ -11,6 +11,13 @@ module HTTP
             '/resource-target'
           end
 
+          def self.uri(scheme=nil)
+            scheme ||= 'HTTP'
+
+            cls = ::URI.const_get scheme
+            cls.build :host => host, :path => resource_target
+          end
+
           module Get
             def self.example
               <<-HTTP

--- a/lib/http/commands/get.rb
+++ b/lib/http/commands/get.rb
@@ -13,6 +13,14 @@ module HTTP
         end
       end
 
+      def self.configure(receiver, attr_name=nil, connection: nil)
+        attr_name ||= :get
+
+        instance = build connection
+        receiver.send "#{attr_name}=", instance
+        instance
+      end
+
       def self.call(uri, headers=nil, connection: nil)
         instance = build connection
         instance.(uri, headers)

--- a/lib/http/commands/get.rb
+++ b/lib/http/commands/get.rb
@@ -1,50 +1,39 @@
 module HTTP
   module Commands
     class Get
-      attr_reader :headers
-      attr_reader :host
-      attr_reader :resource_target
+      attr_accessor :connection
 
-      dependency :connection, Connection::Client
-      dependency :logger
+      dependency :logger, Telemetry::Logger
 
-      def initialize(host, resource_target, headers)
-        @headers = headers
-        @host = host
-        @resource_target = resource_target
+      def self.build(connection=nil)
+        new.tap do |instance|
+          Telemetry::Logger.configure instance
+
+          instance.connection = connection if connection
+        end
       end
 
-      def self.build(uri, headers={}, connection: nil)
+      def self.call(uri, headers=nil, connection: nil)
+        instance = build connection
+        instance.(uri, headers)
+      end
+
+      def call(uri, headers=nil)
+        headers ||= {}
+
         uri = URI(uri)
+        connection = self.connection || Connect.(uri)
 
         resource_target = uri.request_uri
         host = uri.host
 
-        new(host, resource_target, headers).tap do |instance|
-          Telemetry::Logger.configure instance
-
-          if connection
-            instance.connection = connection
-          else
-            Connect.configure_connection instance, uri
-          end
-        end
-      end
-
-      def self.call(*arguments)
-        instance = build(*arguments)
-        instance.()
-      end
-
-      def call
-        request = Request.build(
+        Request.(
           connection,
           'GET',
           host,
           resource_target,
           headers: headers
         )
-        request.()
       end
     end
   end

--- a/lib/http/commands/post.rb
+++ b/lib/http/commands/post.rb
@@ -18,6 +18,14 @@ module HTTP
         instance.(body, uri, headers)
       end
 
+      def self.configure(receiver, attr_name=nil, connection: nil)
+        attr_name ||= :post
+
+        instance = build connection
+        receiver.send "#{attr_name}=", instance
+        instance
+      end
+
       def call(body, uri, headers=nil)
         headers ||= {}
 

--- a/lib/http/commands/request.rb
+++ b/lib/http/commands/request.rb
@@ -9,7 +9,7 @@ module HTTP
 
       dependency :logger, Telemetry::Logger
 
-      def initialize(connection, action, host, target, body: nil, headers: nil)
+      def initialize(connection, action, host, target, body, headers)
         @action = action
         @body = body
         @headers = headers
@@ -18,10 +18,15 @@ module HTTP
         @target = target
       end
 
-      def self.build(*arguments)
-        instance = new *arguments
+      def self.build(connection, action, host, target, body: nil, headers: nil)
+        instance = new connection, action, host, target, body, headers
         Telemetry::Logger.configure instance
         instance
+      end
+
+      def self.call(*arguments)
+        instance = build *arguments
+        instance.()
       end
 
       def call

--- a/test/spec/get.rb
+++ b/test/spec/get.rb
@@ -30,4 +30,12 @@ context 'Get' do
     assert response.status_code == 200
     assert JSON.parse(response.body) == resource
   end
+
+  test "Configuring" do
+    receiver = OpenStruct.new
+
+    HTTP::Commands::Get.configure receiver, :some_attr
+
+    assert receiver.some_attr.is_a?(HTTP::Commands::Get)
+  end
 end

--- a/test/spec/get.rb
+++ b/test/spec/get.rb
@@ -1,18 +1,17 @@
 require_relative './spec_init'
 
 context 'Get' do
-  host = HTTP::Commands::Controls::Messages::Requests.host
-  resource_target = HTTP::Commands::Controls::Messages::Requests.resource_target
+  uri = HTTP::Commands::Controls::Messages::Requests.uri
 
   test do
     resource = HTTP::Commands::Controls::Messages::Resources.text
     expected_request, expected_response = HTTP::Commands::Controls::Dialogs::Get.example resource
+    connection = HTTP::Commands::Controls::Dialogs::Connection.example expected_request, expected_response
 
-    get = HTTP::Commands::Get.new host, resource_target, {}
-    get.connection.expect_write expected_request
-    get.connection.expect_read expected_response
+    get = HTTP::Commands::Get.new
+    get.connection = connection
 
-    response = get.()
+    response = get.(uri)
 
     assert response.status_code == 200
     assert response.body == resource
@@ -21,13 +20,12 @@ context 'Get' do
   test 'Supplying Headers' do
     resource = HTTP::Commands::Controls::Messages::Resources.json
     expected_request, expected_response = HTTP::Commands::Controls::Dialogs::Get::JSON.example resource
-    headers = { 'Accept' => 'application/json' }
+    connection = HTTP::Commands::Controls::Dialogs::Connection.example expected_request, expected_response
 
-    get = HTTP::Commands::Get.new host, resource_target, headers
-    get.connection.expect_write expected_request
-    get.connection.expect_read expected_response
+    get = HTTP::Commands::Get.new
+    get.connection = connection
 
-    response = get.()
+    response = get.(uri, 'Accept' => 'application/json')
 
     assert response.status_code == 200
     assert JSON.parse(response.body) == resource

--- a/test/spec/post.rb
+++ b/test/spec/post.rb
@@ -48,4 +48,12 @@ context 'Post' do
     assert response.status_code == 201
     assert response.body.nil?
   end
+
+  test "Configuring" do
+    receiver = OpenStruct.new
+
+    HTTP::Commands::Post.configure receiver, :some_attr
+
+    assert receiver.some_attr.is_a?(HTTP::Commands::Post)
+  end
 end

--- a/test/spec/post.rb
+++ b/test/spec/post.rb
@@ -1,18 +1,17 @@
 require_relative './spec_init'
 
 context 'Post' do
-  host = HTTP::Commands::Controls::Messages::Requests.host
-  resource_target = HTTP::Commands::Controls::Messages::Requests.resource_target
+  uri = HTTP::Commands::Controls::Messages::Requests.uri
 
   test 'Without Response Body' do
     request_body = HTTP::Commands::Controls::Messages::Resources.example
     expected_request, expected_response = HTTP::Commands::Controls::Dialogs::Post.example request_body
+    connection = HTTP::Commands::Controls::Dialogs::Connection.example expected_request, expected_response
 
-    post = HTTP::Commands::Post.new request_body, host, resource_target, {}
-    post.connection.expect_write expected_request
-    post.connection.expect_read expected_response
+    post = HTTP::Commands::Post.new
+    post.connection = connection
 
-    response = post.()
+    response = post.(request_body, uri, {})
 
     assert response.status_code == 201
     assert response.body.nil?
@@ -21,14 +20,13 @@ context 'Post' do
   test 'With Response Body' do
     request_body = 'some-request'
     response_body = 'some-response'
-
     expected_request, expected_response = HTTP::Commands::Controls::Dialogs::Post.example request_body, response_body
+    connection = HTTP::Commands::Controls::Dialogs::Connection.example expected_request, expected_response
 
-    post = HTTP::Commands::Post.new request_body, host, resource_target, {}
-    post.connection.expect_write expected_request
-    post.connection.expect_read expected_response
+    post = HTTP::Commands::Post.new
+    post.connection = connection
 
-    response = post.()
+    response = post.(request_body, uri, {})
 
     assert response.status_code == 201
     assert response.body == response_body
@@ -40,12 +38,12 @@ context 'Post' do
     resource = HTTP::Commands::Controls::Messages::Resources.json
     request_body = JSON.pretty_generate resource
     expected_request, expected_response = HTTP::Commands::Controls::Dialogs::Post::JSON.example resource
+    connection = HTTP::Commands::Controls::Dialogs::Connection.example expected_request, expected_response
 
-    post = HTTP::Commands::Post.new request_body, host, resource_target, headers
-    post.connection.expect_write expected_request
-    post.connection.expect_read expected_response
+    post = HTTP::Commands::Post.new
+    post.connection = connection
 
-    response = post.()
+    response = post.(request_body, uri, headers)
 
     assert response.status_code == 201
     assert response.body.nil?

--- a/test/spec/request.rb
+++ b/test/spec/request.rb
@@ -1,29 +1,28 @@
 require_relative './spec_init'
 
 context 'Request' do
-  host = HTTP::Commands::Controls::Messages::Requests.host
-  resource_target = HTTP::Commands::Controls::Messages::Requests.resource_target
+  uri = HTTP::Commands::Controls::Messages::Requests.uri
 
   test 'Leaving the Connection Open' do
     expected_request, expected_response = HTTP::Commands::Controls::Dialogs::Get.example
+    connection = HTTP::Commands::Controls::Dialogs::Connection.example expected_request, expected_response
 
-    get = HTTP::Commands::Get.new host, resource_target, {}
-    get.connection.expect_write expected_request
-    get.connection.expect_read expected_response
+    get = HTTP::Commands::Get.new
+    get.connection = connection
 
-    get.()
+    get.(uri)
 
     assert !get.connection.closed?
   end
 
   test "Closing the Connection at Server's Request" do
     expected_request, expected_response = HTTP::Commands::Controls::Dialogs::Get.connection_closed
+    connection = HTTP::Commands::Controls::Dialogs::Connection.example expected_request, expected_response
 
-    get = HTTP::Commands::Get.new host, resource_target, {}
-    get.connection.expect_write expected_request
-    get.connection.expect_read expected_response
+    get = HTTP::Commands::Get.new
+    get.connection = connection
 
-    get.()
+    get.(uri)
 
     assert get.connection.closed?
   end


### PR DESCRIPTION
This added a bit of incidental complexity to the `HTTP::Commands::Post` and `HTTP::Commands::Get` classes, as their dependency to the `connection` cannot be a `subst-attr` dependency any longer. This is because we need to detect when an externally supplied `connection` is _not_ present, and establish a connection inside the `call` method, since the `uri` isn't in any lexical scope before then.
